### PR TITLE
isURL error

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ function wkhtmltopdf(input, options) {
   var args = [wkhtmltopdf.command, '--quiet'];
   for (var key in options) {
     var val = options[key];
-    key = '--' + slang.dasherize(key);
+
+    key = key.length === 1 ? '-' + key : '--' + slang.dasherize(key);
     
     if (val !== false)
       args.push(key);


### PR DESCRIPTION
isURL returns true for input that contains http(s)/file somewhere in the string. It shouldn't, because then `<a href="http://url.com">url</a>` is treated as an URL, not a html string.
