### PR TITLE
Considerable edits to get things working on Windows and added logging option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,28 @@
+//WKHTMLTOPDF
 var spawn = require('child_process').spawn;
 var slang = require('slang');
 
 function wkhtmltopdf(input, options, callback) {
   if (!options) {
-    options = {};
+    options = { quiet: true, logging: false, };
   } else if (typeof options == 'function') {
     callback = options;
-    options = {};
+    options = { quiet: true, logging: false, };
   }
+  var logging = options.logging ? options.logging===true ? true : false : false;
+  delete options.logging;
   
   var output = options.output;
   delete options.output;
   
-  var args = [wkhtmltopdf.command, '--quiet'];
+  var args = [];
+  args.push(wkhtmltopdf.command );
+  
+  if ( options.quiet )
+    args.push('--quiet');
+  delete options.quiet;
+
+
   for (var key in options) {
     var val = options[key];
     key = key.length === 1 ? '-' + key : '--' + slang.dasherize(key);
@@ -28,16 +38,31 @@ function wkhtmltopdf(input, options, callback) {
       args.push(val);
     }
   }
-  
+
   var isUrl = /^(https?|file):\/\//.test(input);
+  if (process.platform === 'win32')
+    input = '"' + input + '"';
+
   args.push(isUrl ? input : '-'); // stdin if HTML given directly
   args.push(output || '-');       // stdout if no output file
 
   if (process.platform === 'win32') {
-    var child = spawn(args[0], args.slice(1));
+    args.unshift('"');    
+    args.unshift('/C');
+    args.push('"');
+    
+    if (logging) {
+      console.log('WKHTMLTOPDF args:\n');
+      console.dir(args);
+      console.log('\n');
+    }
+    
+    var child = spawn('cmd', args, { windowsVerbatimArguments: true });
+    if (logging) logError(child);
   } else {
     // this nasty business prevents piping problems on linux
     var child = spawn('/bin/sh', ['-c', args.join(' ') + ' | cat']);
+    if (logging) logError(child);
   }
 
   if (callback)
@@ -48,6 +73,14 @@ function wkhtmltopdf(input, options, callback) {
   
   // return stdout stream so we can pipe
   return child.stdout;
+}
+
+function logError(child) {
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', function(data) { console.log('(INFO) WKHTML INFO --------------------------- \n'); console.dir(data); });
+  
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', function(data) { console.log('(ERROR) WKHTML ERROR --------------------------- \n'); console.dir(data); });
 }
 
 wkhtmltopdf.command = 'wkhtmltopdf';


### PR DESCRIPTION
Updated to use cmd /c "command args" on win32 platform

Added console.log logging with options.logging=true (default is false)

Various other optimizations.

Tested extensively on Windows 8.1. Expected wkhtmltopdf command in path and at present the installer
does NOT provide this so user must edit their path manually.
