### PR TITLE
Fixes use of file:// closes #15

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ function wkhtmltopdf(input, options, callback) {
   }
   
   var isUrl = /^(https?|file):\/\//.test(input);
+  var fileMatch = /^file:\/\/(.*)/.exec(input);
+  if (fileMatch && fileMatch[1]) {
+    input = fileMatch[1];
+  }
   args.push(isUrl ? input : '-'); // stdin if HTML given directly
   args.push(output || '-');       // stdout if no output file
 


### PR DESCRIPTION
If you specify `file://filename.md` then rather than using that as the input, `file://` is stripped.
