### PR TITLE
Added support for JS debug statement returns via quiet:false.

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function wkhtmltopdf(input, options, callback) {
 
   child.stderr.on('data', function(err) {
     if (err.toString().indexOf('Warning: ' === 0))
-      warnings.push(msg);
+      warnings.push(err.toString());
     else if (err.toString().indexOf('Error: ' === 0)) {
       handleError(new Error((err || '').toString().trim()));
       child.stderr.removeAllListeners('data');

--- a/index.js
+++ b/index.js
@@ -83,9 +83,9 @@ function wkhtmltopdf(input, options, callback) {
   child.once('error', handleError);
 
   child.stderr.on('data', function(err) {
-    if (err.toString().indexOf('Warning: ' >= 0))
+    if (err.toString().indexOf('Warning: ') >= 0)
       warnings.push(err.toString());
-    else if (err.toString().indexOf('Error: ' >= 0)) {
+    else if (err.toString().indexOf('Error: ') >= 0) {
       handleError(new Error((err || '').toString().trim()));
       child.stderr.removeAllListeners('data');
     }

--- a/index.js
+++ b/index.js
@@ -83,9 +83,9 @@ function wkhtmltopdf(input, options, callback) {
   child.once('error', handleError);
 
   child.stderr.on('data', function(err) {
-    if (err.toString().indexOf('Warning: ' === 0))
+    if (err.toString().indexOf('Warning: ' >= 0))
       warnings.push(err.toString());
-    else if (err.toString().indexOf('Error: ' === 0)) {
+    else if (err.toString().indexOf('Error: ' >= 0)) {
       handleError(new Error((err || '').toString().trim()));
       child.stderr.removeAllListeners('data');
     }

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ function wkhtmltopdf(input, options, callback) {
       
     if (typeof val !== 'boolean')
       args.push(quote(val));
+
+    if (key === '--quiet' && val === false) {
+      args.splice(args.indexOf(key), 1);
+    }
   });
   
   var isUrl = /^(https?|file):\/\//.test(input);
@@ -55,9 +59,11 @@ function wkhtmltopdf(input, options, callback) {
     var child = spawn('/bin/sh', ['-c', args.join(' ') + ' | cat']);
   }
   
+  var warnings = [];
+
   // call the callback with null error when the process exits successfully
   if (callback)
-    child.on('exit', function() { callback(null); });
+    child.on('exit', function() { callback(null, null, warnings); });
     
   // setup error handling
   var stream = child.stdout;
@@ -75,8 +81,14 @@ function wkhtmltopdf(input, options, callback) {
   }
   
   child.once('error', handleError);
-  child.stderr.once('data', function(err) {
-    handleError(new Error((err || '').toString().trim()));
+
+  child.stderr.on('data', function(err) {
+    if (err.toString().indexOf('Warning: ' === 0))
+      warnings.push(msg);
+    else if (err.toString().indexOf('Error: ' === 0)) {
+      handleError(new Error((err || '').toString().trim()));
+      child.stderr.removeAllListeners('data');
+    }
   });
   
   // write input to stdin if it isn't a url


### PR DESCRIPTION
wkhtmltopdf's `--quiet` parameter takes precedence over `--debug-javascript`, so you don't get JS errors or debug statements even if you explicitly indicate that you want them.

Since node-wkhtmltopdf automatically includes the `--quiet` parameter, this silences all JS debug output. This commit removes `--quiet` if `{quiet: false}` is specified as part of the options object. The event listener for stderr has been modified to disregard the usual text that wkhtmltopdf outputs regarding progress, while keeping track of any JS warnings and falling back to the previous behavior in case of actual errors.

The callback, if provided, is executed with a third parameter - an array of all JS messages printed by wkhtmltopdf. This allows for much more effective debugging of complex JS-heavy reports.