### PR TITLE
Handle --xsl-style-sheet positioning

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function wkhtmltopdf(input, options, callback) {
   // make sure the special keys are last
   var extraKeys = [];
   var keys = Object.keys(options).filter(function(key) {
-    if (key === 'toc' || key === 'xslStyleSheet' || key === 'cover' || key === 'page') {
+    if (key === 'toc' || key === 'disableTocLinks' || key === 'xslStyleSheet' || key === 'cover' || key === 'page') {
       extraKeys.push(key);
       return false;
     }

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function wkhtmltopdf(input, options, callback) {
   // make sure the special keys are last
   var extraKeys = [];
   var keys = Object.keys(options).filter(function(key) {
-    if (key === 'toc' || key === 'cover' || key === 'page') {
+    if (key === 'toc' || key === 'xslStyleSheet' || key === 'cover' || key === 'page') {
       extraKeys.push(key);
       return false;
     }


### PR DESCRIPTION
Right now using `--xsl-style-sheet` will throw `specified in incorrect location` error because it needs to be after `toc` argument