### PR TITLE
#33: added support for multi-source input

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,13 @@
     "type": "git",
     "url": "https://github.com/devongovett/node-wkhtmltopdf.git"
   },
+  "scripts": {
+    "test": "mocha -R spec"
+  },
+  "devDependencies": {
+    "mocha": "~2.2.5"
+  },
+  
   "bugs": "http://github.com/devongovett/node-wkhtmltopdf/issues"
+  
 }

--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,11 @@ wkhtmltopdf('http://google.com/', { pageSize: 'letter' }, function (code, signal
 });
 wkhtmltopdf('http://google.com/', function (code, signal) {
 });
+
 ```
 
-`wkhtmltopdf` is just a function, which you call with either a URL or an inline HTML string, and it returns
-a stream that you can read from or pipe to wherever you like (e.g. a file, or an HTTP response).
+`wkhtmltopdf` is just a function, which you call with a URL or inline HTML string, or an Array of objects (see [Multi-Source-Input](#multi-source-input)), 
+and it returns a stream that you can read from or pipe to wherever you like (e.g. a file, or an HTTP response).
 
 There are [many options](http://wkhtmltopdf.org/docs.html) available to
 wkhtmltopdf.  All of the command line options are supported as documented on the page linked to above.  The
@@ -36,6 +37,22 @@ options are camelCased instead-of-dashed as in the command line tool.
 
 There is also an `output` option that can be used to write the output directly to a filename, instead of returning
 a stream.
+
+### Multi-Source-Input
+
+`wkhtmltopdf` supports the ability to construct a PDF from several source documents, and can even generate a table-of-contents based on an outline inferred from the source HTML structure. To combine several documents into a single PDF, pass an array as the first argument. Each element of the array represents a single source for the resulting PDF, and must be either:
+
+ * A string containing the source URL or the string `toc` to generate a Table of Contents
+ * An object conforming to the following structure:
+
+```
+  {
+    type: STRING,     // Optional: 'cover' or 'toc'
+    url: STRING,      // URL to source. Omit for type: 'toc'
+    options: {...},   // Page-specific options. Same format as global options
+  }  
+```
+
 
 ## Installation
 
@@ -49,6 +66,12 @@ Finally, to install the node module, use `npm`:
     
 Be sure `wkhtmltopdf` is in your PATH when you're done installing.  If you don't want to do this for some reason, you can change
 the `wkhtmltopdf.command` property to the path to the `wkhtmltopdf` command line tool.
+    
+## Testing
+
+```
+npm test
+```
     
 ## License
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,42 @@
+var wkhtmltopdf = require('../index.js');
+
+describe('wkhtmltopdf', function() {
+
+  describe('function', function() {
+    var options = {
+      headerCenter: "TEST PDF",
+      headerFontSize: 10,
+      headerSpacing: 5,
+      marginTop: 15,
+      output: "./google.pdf"
+    };
+
+    it('should generate a PDF from a single source and global options', function() {
+      wkhtmltopdf('http://google.com', options);
+    });
+
+    it('should support multiple pages with individual page options', function() {
+      options.output = 'multi-page.pdf';
+
+      var pages = [
+        {
+          type: 'cover',
+          url: 'http://google.com'
+        },
+        'toc', 
+        {
+          url: 'https://github.com',
+          options: {
+            enableTocBackLinks: true,
+            pageOffset: -2
+          }
+        },
+        'http://wkhtmltopdf.org/usage/wkhtmltopdf.txt'
+      ];
+
+      wkhtmltopdf(pages, options);
+    });
+
+  });
+
+});


### PR DESCRIPTION
this adds support for the multi-file concatenation features of the underlying `wkhtmltopdf` library, including cover-page and TOC generation, with options on a per-source basis.

Also, added a couple of basic tests while I was working on this.