### PR TITLE
Added options.ignore to ignore warning messages from wkthmltopdf

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,6 @@ wkhtmltopdf's package maintainer suggests the warning message is harmless and an
 
 ## Usage
 
-API
-
 ### wkhtmltopdf(source, [options], [callback]);
 
 ```javascript

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,21 @@ node-wkhtmltopdf
 A Node.js wrapper for the [wkhtmltopdf](http://wkhtmltopdf.org/) command line tool.  As the name implies, 
 it converts HTML documents to PDFs using WebKit.
 
+Code adopted from [Devon Govett](https://github.com/devongovett/node-wkhtmltopdf)'s project
+
+## Changes
+
+`options.ignore` Array to ignore any warnings that wkhtmltopdf writes to stderr.
+
+wkhtmltopdf often prints to stderr the warning message `QFont::setPixelSize: Pixel size <= 0 (0)`
+
+wkhtmltopdf's package maintainer suggests the warning message is harmless and an [upstream issue](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2124).
+
 ## Usage
+
+API
+
+### wkhtmltopdf(source, [options], [callback]);
 
 ```javascript
 var wkhtmltopdf = require('wkhtmltopdf');
@@ -24,6 +38,17 @@ wkhtmltopdf('http://apple.com/', { output: 'out.pdf' });
 wkhtmltopdf('http://google.com/', { pageSize: 'letter' }, function (code, signal) {
 });
 wkhtmltopdf('http://google.com/', function (code, signal) {
+});
+
+// Ignore warning strings
+wkhtmltopdf('http://apple.com/', { 
+  output: 'out.pdf',
+  ignore: ['QFont::setPixelSize: Pixel size <= 0 (0)']
+});
+// RegExp also acceptable
+wkhtmltopdf('http://apple.com/', { 
+  output: 'out.pdf',
+  ignore: [/QFont::setPixelSize/]
 });
 ```
 


### PR DESCRIPTION
### Summary
* Does not break existing API/functionality
* Quick and easy way to address the concern with #31  
* Adds `options.ignore` key to ignore certain warning messages printed to stderr and prevent the killing of child process

### Details
wkhtmltopdf prints out both error messages and warning messages to stderr. 
The current module will kill the child process once it detects something is written to stderr; however, some messages written to stderr such as `QFont::setPixelSize: Pixel size <= 0 (0)` is entirely harmless according to wkhtmltopdf's GitHub [issue](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2124)
`options.ignore` is accepted as an array of strings or RegExps and will ignore any warning messages that match the array's contents.

Thanks for making this awesome wrapper, it's helped me a lot. 