### PR TITLE
Pass options object to internal spawn invocation

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function wkhtmltopdf(input, options, callback) {
   var output = options.output;
   var spawnOptions = options.spawnOptions;
   delete options.output;
+  delete options.spawnOptions;
 
   // make sure the special keys are last
   var extraKeys = [];

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function wkhtmltopdf(input, options, callback) {
   }
 
   var output = options.output;
+  var spawnOptions = options.spawnOptions;
   delete options.output;
 
   // make sure the special keys are last
@@ -95,14 +96,14 @@ function wkhtmltopdf(input, options, callback) {
   }
 
   if (process.platform === 'win32') {
-    var child = spawn(args[0], args.slice(1));
+    var child = spawn(args[0], args.slice(1), spawnOptions);
   } else if (process.platform === 'darwin') {
-    var child = spawn('/bin/sh', ['-c', args.join(' ') + ' | cat ; exit ${PIPESTATUS[0]}']);
+    var child = spawn('/bin/sh', ['-c', args.join(' ') + ' | cat ; exit ${PIPESTATUS[0]}'], spawnOptions);
   } else {
     // this nasty business prevents piping problems on linux
     // The return code should be that of wkhtmltopdf and not of cat
     // http://stackoverflow.com/a/18295541/1705056
-    var child = spawn(wkhtmltopdf.shell, ['-c', args.join(' ') + ' | cat ; exit ${PIPESTATUS[0]}']);
+    var child = spawn(wkhtmltopdf.shell, ['-c', args.join(' ') + ' | cat ; exit ${PIPESTATUS[0]}'], spawnOptions);
   }
 
   var stream = child.stdout;


### PR DESCRIPTION
I had an issue similar to #9 in my windows environment. 

Basically my implementation passes a cookie argument which has three parts according to the wkhtmltopdf documentation. 

So 

```
    wkhtmltopdf("http://source", { output: "C:\dest.pdf", cookie: "<name> <value>" })
```

is ultimately executed on Windows as 
```
     wkhtmltopdf <other arguments> --cookie "<name> <value>" http://source C:\dest.pdf
```

with quotes. Instead of

```
     wkhtmltopdf <other arguments> --cookie <name> <value> http://source C:\dest.pdf
```

without quotes.

The resolution for this case, as also noted in #9, is to pass the ```windowsVerbatimArguments``` option to spawn.

Instead of hard coding it into the library. I figured it would be more flexible to leave it up to the implementation to pass the argument. So

```
    wkhtmltopdf("http://source", { output: "C:\dest.pdf", cookie: "<name> <value>" })
```
becomes

```
        wkhtmltopdf("http://source", {
            output: "C:\dest.pdf", 
            cookie: "<name> <value>", 
            spawnOptions: { 
                windowsVerbatimArguments: true 
            }
        })
```

It is also unfortunate that this option is not documented though it's been implemented since 2011. (https://github.com/nodejs/node-v0.x-archive/pull/4259)
