### PR TITLE
Add compatibility with /bin/ash on Alpine Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,12 +97,12 @@ function wkhtmltopdf(input, options, callback) {
   if (process.platform === 'win32') {
     var child = spawn(args[0], args.slice(1));
   } else if (process.platform === 'darwin') {
-    var child = spawn('/bin/sh', ['-c', args.join(' ') + ' | cat ; exit ${PIPESTATUS[0]}']);
+    var child = spawn('/bin/sh', ['-c', 'set -o pipefail ; ' + args.join(' ') + ' | cat']);
   } else {
     // this nasty business prevents piping problems on linux
     // The return code should be that of wkhtmltopdf and not of cat
     // http://stackoverflow.com/a/18295541/1705056
-    var child = spawn(wkhtmltopdf.shell, ['-c', args.join(' ') + ' | cat ; exit ${PIPESTATUS[0]}']);
+    var child = spawn(wkhtmltopdf.shell, ['-c', 'set -o pipefail ; ' + args.join(' ') + ' | cat']);
   }
 
   var stream = child.stdout;

--- a/spec/wkhtmltopdf.spec.js
+++ b/spec/wkhtmltopdf.spec.js
@@ -5,6 +5,7 @@ var Path = require('path'),
   Mkdirp = require('mkdirp'),
   Wkhtmltopdf = require('..');
 
+Wkhtmltopdf.shell = process.env.WKHTMLTOPDF_SHELL || Wkhtmltopdf.shell
 
 describe('wkhtmltopdf', function() {
 


### PR DESCRIPTION
Because `${PIPESTATUS[0]}` is Bash-specific, this package does not support Alpine Linux (one of the most popular distributions for Docker containers). Since `ash`, the default shell in Alpine, does not support `${PIPESTATUS[0]}`, this package fails with weird errors when running in a common Docker setup (e.g. images like [one of these](https://hub.docker.com/u/surnet/)).

With this patch, `ash` works as expected - as does `bash`. I don't have a macOS computer available, but I imagine it still works there as well, as the code for that case has not changed.

You can test on Ubuntu and Alpine yourself by adding the following Dockerfiles to the project root, and running `docker build . -f Dockerfile.<distro>`. The current test suite passes in both of them.

### Dockerfile.alpine
```
FROM surnet/alpine-node-wkhtmltopdf

ENV WKHTMLTOPDF_SHELL='/bin/ash'

COPY package.json .

RUN yarn install

COPY . .

RUN yarn test
```

### Dockerfile.ubuntu
```
FROM openlabs/docker-wkhtmltopdf

# Install node and yarn
RUN apt-get update &&\
    apt-get install -y curl && \
    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
    apt-get install -y nodejs yarn

ENV WKHTMLTOPDF_SHELL='/bin/bash'

COPY package.json .

RUN yarn install

COPY . .

RUN yarn test
```