### PR TITLE
Allow passing null to input.

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,11 @@ function wkhtmltopdf(input, options, callback) {
   });
 
   var isUrl = /^(https?|file):\/\//.test(input);
-  args.push(isUrl ? quote(input) : '-');    // stdin if HTML given directly
+
+  if (input) {
+    args.push(isUrl ? quote(input) : '-');    // stdin if HTML given directly
+  }
+
   args.push(output ? quote(output) : '-');  // stdout if no output file
 
   // show the command that is being run if debug opion is passed


### PR DESCRIPTION
I have a situation where I need to add the Table of Contents (toc) to the end of a pdf document (i.e. an Index). This works out of the box with the following configuration example (passing null to input, specify html as a page, then toc), but a blank page is added to the end of the document due to how the options are sent to wkhtmltopdf by this library.

`wkhtmltopdf(null, { page: '/tmp/maindoc.html', toc: true });`

This tiny PR fixes/removes the blank page by only processing input if it exists.