### PR TITLE
Handle readArgsFromStdin correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,13 +100,15 @@ function wkhtmltopdf(input, options, callback) {
     })
   } else {
     var isUrl = /^(https?|file):\/\//.test(input);
-    if (input) {
+    if (input && !options.readArgsFromStdin) {
       args.push(isUrl ? quote(input) : '-');    // stdin if HTML given directly
     }
   }
 
   // Output
-  args.push(output ? quote(output) : '-');  // stdout if no output file
+  if (!options.readArgsFromStdin) {
+    args.push(output ? quote(output) : '-');  // stdout if no output file
+  }
 
   // show the command that is being run if debug opion is passed
   if (options.debug && !(options instanceof Function)) {

--- a/spec/wkhtmltopdf.spec.js
+++ b/spec/wkhtmltopdf.spec.js
@@ -96,6 +96,22 @@ describe('wkhtmltopdf', function() {
     });
   });
 
+  describe('when readArgsFromStdin is set', function() {
+    it('should treat input as arguments', function(done) {
+      var args = [
+        'page',
+        fixtureFileUri('validFile.html'),
+        '-'
+      ];
+      var output = Fs.createWriteStream(resultPath('readArgsFromStdinSpec.pdf'));
+      Wkhtmltopdf(args.join(' '), { readArgsFromStdin: true }).pipe(output);
+      output.on('finish', function() {
+        checkResults('readArgsFromStdinSpec.pdf', 'validFile.pdf');
+        done();
+      });
+    });
+  });
+
   describe('when callback is used', function() {
     it('should return a readable stream', function(done) {
       Wkhtmltopdf(Fs.createReadStream(fixturePath('validFile.html')), function(err, stream) {


### PR DESCRIPTION
remove the stdin/stdout dash if readArgsFromStdin is set to avoid 2 blank pages on pdf generation.